### PR TITLE
Import bylaws to markdown

### DIFF
--- a/BYLAWS.md
+++ b/BYLAWS.md
@@ -1,0 +1,282 @@
+# Bylaws of Pawprint Prototyping
+
+Revision 1.0
+
+## Preamble
+
+As members of the hacking community, we the representatives of Pawprint Prototyping (herein also written as simply the Hackerspace), in the desire to promote our mission and to better govern ourselves, hereby lay down the following ground rules for executing the Business of our organization:
+
+## 1. Mission, Purpose and Location
+
+1. Pawprint Prototyping’s Mission is to:
+    1. Establish and maintain a community space wherein the Hackerspace’s Members may gather, work on projects, collaborate, and share knowledge;
+    2. Foster a network for innovative thinking, education, and creative endeavors in our local community and the hacker community at large.
+2. Notwithstanding anything herein to the contrary, Pawprint Prototyping is organized exclusively for charitable, educational, and scientific purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code of 1986 (or the corresponding section of any future federal tax code).
+3. Notwithstanding anything herein to the contrary, Pawprint Prototyping shall not, except to an insubstantial degree, engage in any activities or exercise any powers that are in themselves not in furtherance of one or more exempt purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code of 1986 (or the corresponding section of any future federal tax code).
+3. Pawprint Prototyping shall continuously maintain in the State of California a registered office and a registered agent whose business office, for the purposes of this organization, is identical with such registered office. The registered office shall be the physical location of the Hackerspace. In the event that we do not have a physical location, the registered office shall be determined by the Board of Directors.
+
+## 2. Users and Members
+1. The Hackerspace shall comprise of the following types of persons (herein also referred to as Users) who may utilize its physical facilities (herein also referred to as the Space):
+    1. Guest - a User who has not signed a Membership Agreement nor has been inducted into the Membership of the Hackerspace, but may sign a Release of Liability;
+    2. Full Member - a User that has been accepted into the Membership of the Hackerspace, who pays at least the full monthly Membership Fee and receives all membership benefits, as established in these Bylaws and the current Membership Agreement.
+2. The Users of the Hackerspace are granted the following privileges:
+    1. Guests may, upon completing and signing a Release of Liability:
+        1. Be present at the Space when accompanied by a current Member who will assume responsibility for the Guest;
+        2. Utilize the general facilities of the Space and participate in the Hackerspace’s public workshops/classes;
+        3. Use tools present in the Space under the supervision of a Member, as long as they have been certified by a qualified Member for each type of tool and have a completed Record of Equipment Certification on file with the Board of Directors.
+    2. Full Members enjoy all privileges of Guests and may also:
+        1. Have access to the private Member mailing list;
+        2. Be present in the Space during normal operating hours and under normal conditions;
+        3. Obtain a personal method of access to the Space from the Board of Directors, such as a physical key or electronic key fob;
+        4. Participate in Business Meetings of the Hackerspace with eligibility to cast votes on formal motions of Business;
+        5. Be nominated and elected onto the Board of Directors;
+        6. Enjoy any other privileges of Full Membership as listed in the current Membership Agreement.
+3. Members have the following obligations and responsibilities:
+    1. Support the Mission and Purpose of the Hackerspace;
+    2. Follow the Rules of the Hackerspace;
+    3. Follow the contractual obligations of the Membership Agreement and associated documents;
+    4. Disclose all pertinent conflicts of interest in matters concerning Hackerspace business.
+4. Admission to the Membership
+    1. All individuals 18 years of age or older who support the Mission and Purpose of the Hackerspace are eligible for Hackerspace Membership.
+    2. To apply for Membership, the eligible individual must be nominated by an existing member, complete the latest Membership Agreement (and associated forms) and present the paperwork and first Membership Fee payment to the Board of Directors. 
+    3. To be accepted into Membership upon applying, the individual must present the Board of Directors with their government-issued photo identification and have two Board Members sign their Membership Agreement. Any individual who complies with the above requirements (at the discretion of the Board of Directors) becomes a Member of the Hackerspace.
+    4. All new members must be entered into a register of Membership (herein also referred to as the Register).
+5. Suspension and Termination of Membership
+    1. Any Member may terminate or suspend their own Membership by giving written notice to the Board of Directors. Such Member shall retain Guest status until they decide to restore their Membership.
+    2. Membership is suspended by the Hackerspace in the following way:
+        1. If a Member does not pay the Membership Fee by the date set in the current Membership Agreement, or owes any other monetary debt to the Hackerspace deemed delinquent by the Board of Directors, they may have their Membership suspended.
+        2. The Board of Directors will give written notice to the Member stating that unless the debt is paid by a nominated date, the individual’s Membership will be suspended effective the nominated date.
+        3. After the nominated date, the Suspended Member shall, without being released from the obligation of payment of any sums due to the Hackerspace, have no Membership rights and shall not be entitled to participate in any Hackerspace activities.
+        4. If the Suspended Member repays the debt owed to the Hackerspace, they may have their Membership resumed with all previous rights and privileges, at the discretion of the Board of Directors.
+    3. Membership is terminated by the Hackerspace in the following way:
+        1. If, for any reason whatsoever, the Board of Directors is of the opinion that a Member is breaching the Rules or acting in a manner inappropriate to the purposes of the Hackerspace, the Board of Directors will give a written notice of misconduct to the Member. This notice must:
+            1. Explain how the Member is breaching the Rules or acting in a manner inappropriate to the purposes of the Hackerspace;
+            2. State what the Member must do in order to remedy the situation or state that the Member must write back to the Board of Directors giving reasons why the Board should not terminate the Member’s Membership;
+            3. State that if, after fourteen (14) days of the Member being presented with the written notice of misconduct, the Board of Directors is not satisfied with the Member’s actions to remedy the situation, the Board may in its absolute discretion immediately terminate the Member’s Membership;
+            4. State that if the Board of Directors terminates the Member’s Membership, the Terminated Member may appeal to the Membership of the Hackerspace for a hearing to reinstate their Membership.
+        2. Fourteen (14) days after the Member is presented with the written notice of misconduct, the Board of Directors may in its absolute discretion, vote to terminate the Member’s Membership, which takes immediate effect.
+        3. The Terminated Member must be given a written notice of the termination shortly following the Board of Director’s decision to terminate the Member. The notice must:
+            1. State that the Terminated Member has the right to challenge the Board’s decision by appealing to the Membership of the Hackerspace;
+            2. State that the appeal must be submitted, in written form, to the Secretary within fourteen (14) days of being presented this termination notice;
+            3. State that, if the Terminated Member so chooses, they may provide the Secretary with a written explanation of the events as they see them, and they may require the Secretary to distribute this written explanation to the Membership of the Hackerspace within seven (7) days of the Secretary receiving it.
+        4. If the Terminated Member gives a written notice to appeal to the Secretary, they will have the right to be fairly heard at a Monthly Meeting held within the following ninety (90) days.
+        5. If the Terminated Member is not satisfied that the Membership of the Hackerspace has had sufficient time to consider the written explanation, they may defer his or her right to be heard until the following Monthly Meeting.
+        6. When the Terminated Member is heard at a Monthly Meeting, other Members of the Hackerspace may question the Terminated Member and the Members of the Board of Directors. The Membership of the Hackerspace shall then hold a vote to decide whether to let Board decision stand or to reinstate the Terminated Member. This decision will be final.
+    4. Membership is automatically terminated upon the death of a Member.
+    5. At the time an individual’s Membership is suspended or terminated, they must forfeit their method of entry into the Space, in addition to any other property owned by the Hackerspace, to a member of the Board of Directors or an agent delegated by the Board for this purpose.
+    6. The Membership Agreement shall define additional terms and procedures for suspension or termination of Membership.
+
+6. The Register of Members
+    1. The Secretary shall maintain the Register of Members.
+    2. If a Member’s contact details change, that Member shall give the new information to the Secretary.
+    3. Each Member shall provide personal information as the Board of Directors requires.
+    4. Members shall have reasonable access to the Register.
+    5. Under no circumstances may Members use information obtained from the Register to contact or send material to another Member for the purposes of advertising for political, religious, charitable, or commercial purposes.
+
+## 3. Management
+1. The Hackerspace shall have a management committee (herein also referred to as the Board of Directors, or simply the Board) comprised of, at a minimum, the following Director positions (herein also referred to as Core Director positions):
+    1. President;
+    2. Vice President;
+    3. Treasurer;
+    4. Secretary;
+    5. Chief Technology Officer.
+2. Supplemental Director positions may be added to or removed from the Board of Directors to fulfill Business needs of the Hackerspace or to fairly represent Member interests. The addition and removal of such positions shall require a vote of the Membership. Core Director positions may not be added or removed without amending these Bylaws.
+3. Nomination and Election of Board Members
+    1. The Hackerspace shall hold a special Monthly Meeting, or part of a Monthly Meeting, to select Members for Director positions (herein also referred to as an Elections Meeting or simply Elections).
+    2. During Elections, Members may vote to decide:
+        1. Which supplemental Director positions shall be added or removed from the Board of Directors;
+        2. The term length for any Director position slated for election;
+        3. The number of terms a Member may hold a Director position;
+        4. Which Member shall hold each individual Director position slated for election.
+    3. Elections must occur ahead of every term expiration and at least once every twelve (12) months.
+    4.  Any individual who has been a Member of the organization for a minimum of six (6) months is eligible to be nominated for the Board of Directors.
+    5. Nominations shall be open for at least two (2) Monthly Meetings before Elections.
+    6. Nominations for each Director position are open until the vote is called.
+    7. To be valid, nominations must be expressed to the current Secretary using any of the following methods:
+        1. By voice, whether in public during the Monthly Meeting or in private;
+        2. Via email, whether publicly on the Members’ List or via private emails;
+        3. Using common mobile messaging mediums, such as SMS and instant messaging;
+        4. Any such method the Secretary will find acceptable.
+    8. Nominees must accept the nomination before they can be included on the ballot.
+    9. A Member may nominate themselves for a Director position.
+    10. A nominee may, at any point before the vote is called, rescind their nomination.
+    11. All retiring Board Members are eligible for re-election.
+    12. A Member may be nominated for more than one Director position, however no Member shall be elected or hold power for more than one Director position.
+    13. If the Director position of any Board Member becomes vacant between Elections, the Board of Directors may appoint another Full Member to fill that vacancy until the position’s term expires. 
+    14. If a Board Member is absent from three consecutive Board Meetings without leave of absence, the rest of the Board of Directors may declare that person’s position vacant.
+4. Subject to these Bylaws, the role of the Board of Directors is to:
+    1. Uphold the Mission and Purpose of the Hackerspace;
+    2. Administer and manage the Hackerspace;
+    3. Carry out the day to day business of the Hackerspace, and use money and/or other Hackerspace assets to do so;
+    4. Manage the Hackerspace’s financial affairs, providing financial oversight and approving the budget;
+    5. Set accounting policies in line with generally accepted accounting practice;
+    6. Delegate responsibilities pertaining to Hackerspace Business to individual Members, as necessary;
+    7. Ensure that all Members and Guests follow the Rules;
+    8. Ensure legal and ethical integrity;
+    9. Mitigate risk and liability to the Hackerspace;
+    10. Decide how and if a person becomes a Member, and how and if a person stops being a Member;
+    11. Decide the time and dates for Meetings, and set agenda for the Meetings;
+    12. Decide the procedures for dealing with complaints;
+    13. Set Membership Dues and other fees;
+    14. Make rules and regulations.
+5. The Board of Directors has all the powers of the Hackerspace, unless the Board’s power is limited by these Bylaws, or by a vote of the Membership.
+6. Decisions of the Board of Directors are binding on the Hackerspace, unless the Board’s power is limited by these Bylaws or by a vote of the Membership.
+7. Roles and Responsibilities of the Board Members
+    1. The President is the executive officer of the organization and in this capacity shall:
+        1. Ensure that the Rules are followed by all Members;
+        2. Serve as the chairman of the Board of Directors;
+        3. Be the primary spokesperson for the Hackerspace;
+        4. Convene meetings, establishing whether or not a Quorum is present;
+        5. Preside over the Meetings, deciding who may speak and when;
+        6. Initiate and recognize votes;
+        7. Provide a regular report of Hackerspace operations.
+    2. The Vice President is the operations officer of the organization and in this capacity shall:
+        1. Act as President should the current President be unable to perform their duties;
+        2. Oversee the internal operation of the Hackerspace;
+        3. Facilitate creation of committees and monitor their operation;
+        4. Perform functions delegated to them by the President.
+    3. The Treasurer is the financial officer of the organization and in this capacity shall:
+        1. Ensure the financial obligations of the Hackerspace are met;
+        2. Ensure all Members pay dues in a timely manner, and that all other financial Member obligations to the organization are met;
+        3. Ensure all financial records are kept as needed, supplying them to the Secretary for archival and presentation as required;
+        4. Prepare financial statements and a financial report for the Monthly Meeting;
+        5. Provide financial information to the Board of Directors as the Board requires;
+        6. Correct financial policies and procedures in place;
+        7. Perform functions delegated to them by the President.
+    4. The Secretary is the officer responsible for the records and correspondence of the organization and in this capacity shall: 
+        1. Record and publish Meeting minutes;
+        2. Keep and maintain the Register of Members;
+        3. Publish the agenda for upcoming Meetings;
+        4. Manage records for the organization, and present them as required;
+        5. Perform functions delegated to them by the President.
+    5. The Chief Technology Officer is the officer responsible for the IT infrastructure and technological systems of the Hackerspace and in this capacity shall:
+        1. Ensure the working order of technical systems and processes vital to the operations of the Hackerspace;
+        2. Maintain and update the Membership Mailing List;
+        3. Perform functions delegated to them by the President.
+8. Cessation of Board Membership
+    1. Members cease to be Board Members when:
+        1. They resign by giving official notice to the rest of the Board of Directors;
+        2. They are removed by a vote of the Membership;
+        3. Their position is declared vacant by the rest of the Board of Directors;
+        4. Their term expires.
+    2. If a Member ceases to be a Board Member, they must give to the Board of Directors all Hackerspace documents and property within one (1) month.
+
+## 4. Business of the Hackerspace
+1. Meetings
+    1. The Hackerspace shall conduct the following types of meetings:
+        1. Monthly Meetings
+            1. Monthly Meetings are general body meetings to be conducted monthly in the Space on a day and time decided by the Board of Directors, with consideration given to accommodate the active Membership.
+            2. Attendance to Monthly Meetings is open to all Members.
+            3. Motions may be voted upon at a Monthly Meeting if at least one (1) more than half of all Members are present (herein also referred to as Member Quorum).
+        2. Board Meetings
+            1. Board Meetings are to be conducted at least once per month on a day and time deemed agreeable to the most Board Members possible.
+            2. If the membership of the Hackerspace consists solely of board members, or if a majority of Board Members vote for such, the Monthly Meeting may be combined with the Board Meeting for that month
+            3. Board Meetings may be held in person, using remote conference tools, or in other formats as the Board of Directors may decide.
+            4. Attendance to Board Meetings is open to any currently active Member. Any Member present at a Board Meeting not on the Board of Directors shall attend in a non-participatory manner only.
+            5. Subject to these Bylaws, the Board of Directors may regulate its own practices at Board Meetings.
+            6. Motions may be voted upon at a Board Meeting if at least one (1) more than half of Board Members are present (herein also referred to as Board Quorum).
+    2. A chairperson shall conduct Hackerspace Meetings. By default, all Hackerspace Meetings shall be chaired by the President. If the President is absent, the Vice President chairs that Meeting. If both the President and Vice President are absent, the President shall appoint another Board Member to chair that Meeting in advance. 
+    3. The chairperson shall adjourn the Meeting if necessary.
+    4. The following agenda format is to be followed during all Hackerspace Meetings:
+        1. Roll call and establishing quorum;
+        2. Reports from Board Members and standing committees;
+        3. Discussion of Old Business;
+        4. Discussion of New Business;
+        5. Announcements and any other discussion for the good of the order.
+    5. Before the start of a Meeting, the chairperson may propose to deviate from the standard agenda format and run the meeting in a manner deemed more efficient for the purposes of that Meeting.
+2. Motions
+    1. Any Full Member may make a motion during the New Business portion of the Meeting. The motion must be seconded by another Full Member to be in order to be discussed.
+    2. The Board of Directors may also decide to put forward motions for the Membership to consider at a particular meeting. These motions do not need to be seconded in order to be discussed.
+    3. The new motion is allotted a brief discussion period established by the chairperson upon being seconded.
+    4. At the conclusion of the discussion, the new motion is automatically tabled until the next Meeting. After tabling, the motion must be announced to all currently active Members (via mailing list or other appropriate medium) and added to the agenda of the next Meeting. 
+    5. A motion may avoid tabling and be held to a vote at any particular Meeting by a vote of the Membership.
+    6. New motions may be proposed outside of Meetings (via mailing list of other appropriate medium). The motion must be proposed at least 24 hours before a Meeting to be added to the agenda of that Meeting. Motions added to the agenda still need to be seconded at the Meeting in order to be discussed.
+3. Voting
+    1. Appropriate quorum is required to hold a Meeting where motions may be voted upon.
+    2. If within a half hour after the time appointed for the Meeting a quorum is not met, the Meeting shall continue without voting procedures or it shall be dissolved.
+    3. Teleconferencing members are considered present at a Meeting, count toward quorum and may vote.
+    4. Votes for specific motions may be submitted by proxy. Appropriate proxies include other Members, mail-in (or email-in) voting and open announcement. The vote by proxy only affects the quorum for the motion in question and has no effect on quorum for the rest of the Meeting.
+    5. On any given motion at a Meeting, the chairperson shall in good faith determine whether to vote by voices (“yay or nay”), a show of hands, or secret ballot. However, if any Member is to request a secret ballot before voting by other methods has begun, voting must then be done by secret ballot for that motion.
+    6. Votes by voices that are too close to call may be validated by calling a division, voting using a different method, or recounting.
+    7. Unless otherwise noted, simple majority (more than half) of present and voting Full Members is the fundamental requirement to pass a motion by a vote of the Membership.
+    8. Two-thirds majority of present and voting Full Members is required to pass motions by vote of the Membership pertaining to:
+        1. Suspending or changing adopted rules;
+        2. Closing or limiting debate;
+        3. Preventing consideration of a motion;
+        4. Limiting the powers of the Board of Directors;
+        5. Overturning decisions made by the Board of Directors;
+        6. Removing supplemental Director positions from the Board of Directors.
+    9. Unless otherwise noted, simple majority (more than half) of all active Board Members is the fundamental requirement to pass a Board motion.
+    10. Two-thirds majority of all active Board Members is required to pass Board motions pertaining to:
+        1. Suspending or changing adopted rules;
+        2. Closing or limiting debate;
+        3. Preventing consideration of a motion;
+        4. Amending these Bylaws.
+    11. The chairperson shall have the power of the tie-breaking vote. Unless voting is performed by secret ballot, the chairperson openly casts a vote only after the results are known and they want their vote to affect the outcome. If the tie still stands, the vote is lost.
+
+## 5. Use of Assets
+1. Notwithstanding anything herein to the contrary, the Hackerspace's money and other assets are dedicated to the furtherance of one or more exempt purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code of 1986 (or the corresponding section of any future federal tax code).
+2. No part of the net earnings of the Hackerspace shall become to benefit of, or be distributable to: its members, trustees, officers, or other private persons, except that the Hackerspace shall be authorized and empowered to pay reasonable compensation for services rendered and to make payments and distributions in furtherance of the purposes set forth in the Purpose Statement herein.
+3. No substantial part of the activities of the Hackerspace shall be the carrying on of propaganda, or otherwise attempting to influence legislation, and the Hackerspace shall not participate in, or intervene in (including the publishing or distribution of statements) any political campaign on behalf of or in opposition to any candidate for public office.
+4. Distribution of Assets
+    1. Pawprint Prototyping is organized exclusively for charitable, educational, and scientific purposes, including, for such purposes, the making of distributions to organizations that qualify as exempt organizations under Section 501(c)(3) of the U.S. Internal Revenue Code of 1986 (or the corresponding section of any future federal tax code).
+    2. Upon the dissolution of the Hackerspace, assets shall be distributed for one or more exempt purposes within the meaning of section 501(c)(3) of the Internal Revenue Code of 1986, (or the corresponding section of any future federal tax code) or shall be distributed to the federal government, or to a state or local government, for a public purpose. Any such assets not so disposed of shall be disposed of by a court of competent jurisdiction of the county in which the principal office of the Hackerspace is then located, exclusively for such purposes or to such organization or organizations, as said court shall determine, which are organized and operated exclusively for such purposes.
+
+## 6. Amendment
+1. These Bylaws may be amended when necessary by a Board vote.
+2. All amendments approved by Board vote shall be presented to the Membership for review at the Monthly Meeting following the vote and announced on the appropriate Membership Mailing List thereafter. Members have fourteen (14) days from the date and time of this meeting to motion for a rejection of the amendment.
+3. If the motion for rejection of the amendment is called and seconded, the amendment may not be ratified until motion's vote is resolved. 
+4. If no motion for rejection is called and seconded, the amendment will automatically be ratified at the expiration of the fourteen (14) day period.
+
+## 7. Revision History
+1. 1.0 - 1/5/2020 - Ratified Initial Draft Of Bylaws
+
+## Appendix A - Rules of the Hackerspace
+1. Be excellent to each other - respect your fellow hackers, their privacy and their property. Abide by the Code of Conduct.
+2. Obey all local, state and federal laws while in the Space or at any event associated with the Hackerspace
+3. Do nothing to bring the Hackerspace into disrepute
+4. Promote the purposes and mission of the Hackerspace
+5. Treat all of the Hackerspace’s property with care and respect - all of the Space’s workspaces and tools are shared among all users
+6. Keep the Space clean - pick up after yourself when you are done working on a project and clean up after others
+7. Use common sense and personal responsibility in the Space
+8. Do not use tools you are not authorized to use
+9. Err on the side of doing things - if you want to do something at Pawprint Prototyping, just do it
+10. Vouch only for guests you’d welcome in your own home
+
+## Appendix B - Code of Conduct
+The Pawprint Prototyping Code of Conduct is forked from the !!Con Code of Conduct. It reads as follows:
+
+### The Short Version
+Pawprint Prototyping is dedicated to providing a harassment-free space for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or anything else. We do not tolerate harassment of hackerspace participants in any form.
+
+All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery may not be appropriate at times.
+
+Be kind to others. Do not insult or put down other members or guests. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for the Pawprint Prototyping.
+
+Members or Guests violating these rules may be asked to leave at the sole discretion of the Board of Directors.
+
+Thank you for helping make this a welcoming, friendly space for all.
+
+### The Longer Version
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, derisive comments regarding technical background, and unwelcome sexual attention.
+
+Members or Guests asked to stop any harassing behavior are expected to comply immediately.
+
+Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for Pawprint Prototyping.
+
+If a member or guest engages in behavior that violates the anti-harassment policy, the board of directors may take any action they deem appropriate, including warning the offender or expulsion from the space.
+
+
+<style type="text/css">
+   /* Indent Formatting */
+   /* Format: 1-a-i-A-1-I */
+   ol {list-style-type: lower-alpha;}
+   ol ol {list-style-type: lower-roman;}
+   ol ol ol { list-style-type: digits;}
+   ol ol ol ol { list-style-type: upper-alpha;}
+   ol ol ol ol ol { list-style-type: decimal;}
+   ol ol ol ol ol ol { list-style-type: upper-roman;}
+   /* https://www.w3schools.com/cssref/pr_list-style-type.asp */
+   /* https://stackoverflow.com/questions/11445453/css-set-li-indent */
+   /* https://stackoverflow.com/questions/13366820/how-do-you-make-lettered-lists-using-markdown */
+</style> 

--- a/BYLAWS.md
+++ b/BYLAWS.md
@@ -13,7 +13,7 @@ As members of the hacking community, we the representatives of Totally Legit Age
     2. Foster a network for innovative thinking, education, and creative endeavors in our local community and the hacker community at large.
 2. Notwithstanding anything herein to the contrary, Pawprint Prototyping is organized exclusively for charitable, educational, and scientific purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code.
 3. Notwithstanding anything herein to the contrary, Pawprint Prototyping shall not, except to an insubstantial degree, engage in any activities or exercise any powers that are in themselves not in furtherance of one or more exempt purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code.
-3. Pawprint Prototyping shall continuously maintain in the State of California a registered office and a registered agent whose business office, is identical with such registered office. The registered office shall be the physical location of the Hackerspace. In the event that Pawprint Prototyping does not have a physical location, the registered office shall be determined by the Board of Directors.
+4. Pawprint Prototyping shall continuously maintain in the State of California a registered office and a registered agent whose business office, is identical with such registered office. The registered office shall be the physical location of the Hackerspace. In the event that Pawprint Prototyping does not have a physical location, the registered office shall be determined by the Board of Directors.
 
 ## 2. Users and Members
 1. The Hackerspace shall comprise of the following types of persons (herein also referred to as Users) who may utilize its physical facilities (herein also referred to as the Space):
@@ -44,8 +44,8 @@ As members of the hacking community, we the representatives of Totally Legit Age
     1. Any Member may terminate or suspend their own Membership by giving written notice to the Board of Directors. Such Member shall retain Guest status until they decide to restore their Membership.
     2. Membership is suspended by the Hackerspace in the following way:
         1. If a Member does not pay the Membership Fee by the date set in the current Membership Agreement, or owes any other monetary debt to the Hackerspace deemed delinquent by the Board of Directors, they may have their Membership suspended.
-        3. After the nominated date, the Suspended Member shall, without being released from the obligation of payment of any sums due to the Hackerspace, have no Membership rights and shall not be entitled to participate in any Hackerspace activities.
-        4. If the Suspended Member repays the debt owed to the Hackerspace, they may have their Membership resumed with all previous rights and privileges, at the discretion of the Board of Directors.
+        2. After the nominated date, the Suspended Member shall, without being released from the obligation of payment of any sums due to the Hackerspace, have no Membership rights and shall not be entitled to participate in any Hackerspace activities.
+        3. If the Suspended Member repays the debt owed to the Hackerspace, they may have their Membership resumed with all previous rights and privileges, at the discretion of the Board of Directors.
     3. Membership is terminated by the Hackerspace in the following way:
         1. If the Board of Directors is of the opinion that a Member breached or is breaching the Rules or acting in a manner inappropriate to the purposes of the Hackerspace, the Board of Directors will give a written notice of misconduct to the Member. This notice must:
             1. Explain how the Member breached, is breaching the Rules or acting in a manner inappropriate to the purposes of the Hackerspace;
@@ -74,9 +74,9 @@ As members of the hacking community, we the representatives of Totally Legit Age
 ## 3. Management
 1. The Hackerspace shall have a management committee (herein also referred to as the Board of Directors, or simply the Board) comprised of, at a minimum, the following Director positions (herein also referred to as Core Director positions):
     1. President;
-    3. Treasurer;
-    4. Secretary;
-    5. Chief Technology Officer.
+    2. Treasurer;
+    3. Secretary;
+    4. Chief Technology Officer.
 2. Supplemental Director positions may be added to or removed from the Board of Directors to fulfill Business needs of the Hackerspace or to fairly represent Member interests. The addition and removal of such positions shall require a vote of the Membership. Core Director positions may not be added or removed without amending these Bylaws.
 3. Nomination and Election of Board Members
     1. The Hackerspace shall hold a special Monthly Meeting, or part of a Monthly Meeting, to select Members for Director positions (herein also referred to as an Elections Meeting or simply Elections).
@@ -92,7 +92,7 @@ As members of the hacking community, we the representatives of Totally Legit Age
     7. To be valid, nominations must be expressed to the current Secretary using any of the following methods:
         1. By voice, whether in public during the Monthly Meeting or in private;
         2. Via email, whether publicly on the established communications channels or via private emails;
-        4. Any such method the Secretary will find acceptable.
+        3. Any such method the Secretary will find acceptable.
     8. Nominees must accept the nomination before they can be included on the ballot.
     9. A Member may nominate themselves for a Director position.
     10. A nominee may, at any point before the vote is called, rescind their nomination.
@@ -260,6 +260,7 @@ Be careful in the words that you choose. Remember that sexist, racist, and other
 If a member or guest engages in behavior that violates the anti-harassment policy, the board of directors may take any action they deem appropriate, including warning the offender or expulsion from the space.
 
 
+<!-- these bylaws best viewed as rendered markdown -->
 <style type="text/css">
    /* Indent Formatting */
    /* Format: 1-a-i-A-1-I */

--- a/BYLAWS.md
+++ b/BYLAWS.md
@@ -181,12 +181,21 @@ As members of the hacking community, we the representatives of Totally Legit Age
     3. The new motion is allotted a brief discussion period established by the chairperson upon being seconded.
     4. At the conclusion of the discussion, the new motion is automatically tabled until the next Meeting. After tabling, the motion must be announced to all currently active Members (via mailing list or other appropriate medium) and added to the agenda of the next Meeting. 
     5. A motion may avoid tabling and be held to a vote at any particular Meeting by a vote of the Membership.
-    6. New motions may be proposed outside of Meetings (via mailing list of other appropriate medium). The motion must be proposed at least 24 hours before a Meeting to be added to the agenda of that Meeting. Motions added to the agenda still need to be seconded at the Meeting in order to be discussed.
+    6. Asynchronously Submitted Motions
+        1. Motions may be submitted asynchronously to the Board in writing and in advance of any regular membership meeting.
+        2. Valid means of asynchronous submissions include but are not limited to: electronic mail, Telegram messenger, Signal messenger, written letter, or SMS.  Verbal communication is not sufficient.
+        3. Members submitting a motion asynchronously must solicit another Member to second their motion before submission.  The Member who seconds the asynchronously submitted motion must be included in that submission.
+        4. All asynchronously submitted motions are to be advertised to the entire Member body by the Board within 72 hours of submission.
+        5. The board shall also begin to solicit proxy votes from members on asynchronously submitted motions as soon as it is advertised to the Member body.  Proxy votes are to be collected in accordance with these bylaws.
+        6. Asynchronously submitted motions must be discussed at the next meeting.
 3. Voting
-    1. Appropriate quorum is required to hold a Meeting where motions may be voted upon.
-    2. If within a half hour after the time appointed for the Meeting a quorum is not met, the Meeting shall continue without voting procedures or it shall be dissolved.
     3. Teleconferencing members are considered present at a Meeting, count toward quorum and may vote.
     4. Votes for specific motions may be submitted by proxy. Appropriate proxies include other Members, mail-in (or email-in) voting and open announcement. The vote by proxy only affects the quorum for the motion in question and has no effect on quorum for the rest of the Meeting.
+    3. Votes for specific motions may be submitted by proxy.  A vote by proxy only affects the quorum for the motion in question, and has no effect on quorum for the remainder of the meeting.  Appropriate proxies include:
+        1. Other Members, elected in writing to the Secretary;
+        2. In writing via mail or electronic mail;
+        3. Online polling applications managed by the CTO;
+        4. Open announcement.
     5. On any given motion at a Meeting, the chairperson shall in good faith determine whether to vote by voices (“yay or nay”), a show of hands, or secret ballot. However, if any Member is to request a secret ballot before voting by other methods has begun, voting must then be done by secret ballot for that motion.
     6. Votes by voices that are too close to call may be validated by calling a division, voting using a different method, or recounting.
     7. Unless otherwise noted, a simple majority (more than half) of present and voting Full Members is the fundamental requirement to pass a motion by a vote of the Membership.
@@ -204,6 +213,8 @@ As members of the hacking community, we the representatives of Totally Legit Age
         3. Preventing consideration of a motion;
         4. Amending these Bylaws.
     11. The chairperson shall have the power of the tie-breaking vote. Unless voting is performed by secret ballot, the chairperson openly casts a vote only after the results are known and they want their vote to affect the outcome. If the tie still stands, the vote is lost.
+    12. If a motion has not reached quorum during a meeting, voting must continue outside of the meeting by proxy votes in accordance with these bylaws.  If a motion has not yet reached quorum with proxy votes by the end of the next Meeting, the motion fails.
+    13. Whether or not a motion passes or fails must be communicated to the Member body accordingly.
 
 ## 5. Use of Assets
 1. Notwithstanding anything herein to the contrary, the Hackerspace's money and other assets are dedicated to the furtherance of one or more exempt purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code.
@@ -220,9 +231,15 @@ As members of the hacking community, we the representatives of Totally Legit Age
 4. If no motion for rejection is called and seconded, the amendment will automatically become eligible for ratification at the expiration of the fourteen (14) day period.
 5. Once an amendment of the Bylaws has been ratified, the executed bylaws (as certified by the Secretary) shall be submitted to the appropriate government agencies.
 
-## 7. Revision History
-1. 1.0 - 1/5/2020 - Ratified Initial Draft Of Bylaws
-2. 2.0 - 10/23/2023 - Reviewed and updated Bylaws with current standards
+## 7. Member Communication
+1. The primary channel of Member communication must be a decentralized, open source communication platform.  Secondary communication channels may be any given medium.  The space may communicate using more than one communication channel at once.
+2. The primary means of Member communication is email, using the email address maintained in the Membership portal.  All official communications from the Space to Members must occur over this channel.
+3. The secondary means of Member communication is Telegram messenger.
+
+## 8. Revision History
+1. 1.0 - 2020-01-05 - Ratified Initial Draft Of Bylaws
+2. 2.0 - 2023-10-23 - Reviewed and updated Bylaws with current standards
+3. 3.0 - 2025-04-01 - Updates to motions and voting to better facilitate asynchronously submitted proposals. Add member communications section.
 
 ## Appendix A - Rules of the Hackerspace
 1. Be excellent to each other - respect your fellow hackers, their privacy and their property. Abide by the Code of Conduct.

--- a/BYLAWS.md
+++ b/BYLAWS.md
@@ -1,31 +1,30 @@
 # Bylaws of Pawprint Prototyping
 
-Revision 1.0
+Revision 2.0
 
 ## Preamble
 
-As members of the hacking community, we the representatives of Pawprint Prototyping (herein also written as simply the Hackerspace), in the desire to promote our mission and to better govern ourselves, hereby lay down the following ground rules for executing the Business of our organization:
+As members of the hacking community, we the representatives of Totally Legit Agency, dba Pawprint Prototyping (herein also written as simply the Hackerspace), in the desire to promote our mission and to better govern ourselves, hereby lay down the following ground rules for executing the Business of our organization:
 
 ## 1. Mission, Purpose and Location
 
 1. Pawprint Prototyping’s Mission is to:
     1. Establish and maintain a community space wherein the Hackerspace’s Members may gather, work on projects, collaborate, and share knowledge;
     2. Foster a network for innovative thinking, education, and creative endeavors in our local community and the hacker community at large.
-2. Notwithstanding anything herein to the contrary, Pawprint Prototyping is organized exclusively for charitable, educational, and scientific purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code of 1986 (or the corresponding section of any future federal tax code).
-3. Notwithstanding anything herein to the contrary, Pawprint Prototyping shall not, except to an insubstantial degree, engage in any activities or exercise any powers that are in themselves not in furtherance of one or more exempt purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code of 1986 (or the corresponding section of any future federal tax code).
-3. Pawprint Prototyping shall continuously maintain in the State of California a registered office and a registered agent whose business office, for the purposes of this organization, is identical with such registered office. The registered office shall be the physical location of the Hackerspace. In the event that we do not have a physical location, the registered office shall be determined by the Board of Directors.
+2. Notwithstanding anything herein to the contrary, Pawprint Prototyping is organized exclusively for charitable, educational, and scientific purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code.
+3. Notwithstanding anything herein to the contrary, Pawprint Prototyping shall not, except to an insubstantial degree, engage in any activities or exercise any powers that are in themselves not in furtherance of one or more exempt purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code.
+3. Pawprint Prototyping shall continuously maintain in the State of California a registered office and a registered agent whose business office, is identical with such registered office. The registered office shall be the physical location of the Hackerspace. In the event that Pawprint Prototyping does not have a physical location, the registered office shall be determined by the Board of Directors.
 
 ## 2. Users and Members
 1. The Hackerspace shall comprise of the following types of persons (herein also referred to as Users) who may utilize its physical facilities (herein also referred to as the Space):
     1. Guest - a User who has not signed a Membership Agreement nor has been inducted into the Membership of the Hackerspace, but may sign a Release of Liability;
-    2. Full Member - a User that has been accepted into the Membership of the Hackerspace, who pays at least the full monthly Membership Fee and receives all membership benefits, as established in these Bylaws and the current Membership Agreement.
+    2. Member - a User that has been accepted into the Membership of the Hackerspace, who pays at least the full monthly Membership Fee and receives all membership benefits, as established in these Bylaws and the current Membership Agreement.
 2. The Users of the Hackerspace are granted the following privileges:
     1. Guests may, upon completing and signing a Release of Liability:
-        1. Be present at the Space when accompanied by a current Member who will assume responsibility for the Guest;
+        1. Be present at the Space when accompanied by an active Member who will assume responsibility for the Guest;
         2. Utilize the general facilities of the Space and participate in the Hackerspace’s public workshops/classes;
         3. Use tools present in the Space under the supervision of a Member, as long as they have been certified by a qualified Member for each type of tool and have a completed Record of Equipment Certification on file with the Board of Directors.
-    2. Full Members enjoy all privileges of Guests and may also:
-        1. Have access to the private Member mailing list;
+    2. Members enjoy all privileges of Guests and may also:
         2. Be present in the Space during normal operating hours and under normal conditions;
         3. Obtain a personal method of access to the Space from the Board of Directors, such as a physical key or electronic key fob;
         4. Participate in Business Meetings of the Hackerspace with eligibility to cast votes on formal motions of Business;
@@ -38,19 +37,18 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
     4. Disclose all pertinent conflicts of interest in matters concerning Hackerspace business.
 4. Admission to the Membership
     1. All individuals 18 years of age or older who support the Mission and Purpose of the Hackerspace are eligible for Hackerspace Membership.
-    2. To apply for Membership, the eligible individual must be nominated by an existing member, complete the latest Membership Agreement (and associated forms) and present the paperwork and first Membership Fee payment to the Board of Directors. 
+    2. To apply for Membership, the eligible individual must complete the latest Membership Agreement (and associated forms) and present the paperwork and first Membership Fee payment to the Board of Directors. 
     3. To be accepted into Membership upon applying, the individual must present the Board of Directors with their government-issued photo identification and have two Board Members sign their Membership Agreement. Any individual who complies with the above requirements (at the discretion of the Board of Directors) becomes a Member of the Hackerspace.
     4. All new members must be entered into a register of Membership (herein also referred to as the Register).
 5. Suspension and Termination of Membership
     1. Any Member may terminate or suspend their own Membership by giving written notice to the Board of Directors. Such Member shall retain Guest status until they decide to restore their Membership.
     2. Membership is suspended by the Hackerspace in the following way:
         1. If a Member does not pay the Membership Fee by the date set in the current Membership Agreement, or owes any other monetary debt to the Hackerspace deemed delinquent by the Board of Directors, they may have their Membership suspended.
-        2. The Board of Directors will give written notice to the Member stating that unless the debt is paid by a nominated date, the individual’s Membership will be suspended effective the nominated date.
         3. After the nominated date, the Suspended Member shall, without being released from the obligation of payment of any sums due to the Hackerspace, have no Membership rights and shall not be entitled to participate in any Hackerspace activities.
         4. If the Suspended Member repays the debt owed to the Hackerspace, they may have their Membership resumed with all previous rights and privileges, at the discretion of the Board of Directors.
     3. Membership is terminated by the Hackerspace in the following way:
-        1. If, for any reason whatsoever, the Board of Directors is of the opinion that a Member is breaching the Rules or acting in a manner inappropriate to the purposes of the Hackerspace, the Board of Directors will give a written notice of misconduct to the Member. This notice must:
-            1. Explain how the Member is breaching the Rules or acting in a manner inappropriate to the purposes of the Hackerspace;
+        1. If the Board of Directors is of the opinion that a Member breached or is breaching the Rules or acting in a manner inappropriate to the purposes of the Hackerspace, the Board of Directors will give a written notice of misconduct to the Member. This notice must:
+            1. Explain how the Member breached, is breaching the Rules or acting in a manner inappropriate to the purposes of the Hackerspace;
             2. State what the Member must do in order to remedy the situation or state that the Member must write back to the Board of Directors giving reasons why the Board should not terminate the Member’s Membership;
             3. State that if, after fourteen (14) days of the Member being presented with the written notice of misconduct, the Board of Directors is not satisfied with the Member’s actions to remedy the situation, the Board may in its absolute discretion immediately terminate the Member’s Membership;
             4. State that if the Board of Directors terminates the Member’s Membership, the Terminated Member may appeal to the Membership of the Hackerspace for a hearing to reinstate their Membership.
@@ -58,13 +56,13 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
         3. The Terminated Member must be given a written notice of the termination shortly following the Board of Director’s decision to terminate the Member. The notice must:
             1. State that the Terminated Member has the right to challenge the Board’s decision by appealing to the Membership of the Hackerspace;
             2. State that the appeal must be submitted, in written form, to the Secretary within fourteen (14) days of being presented this termination notice;
-            3. State that, if the Terminated Member so chooses, they may provide the Secretary with a written explanation of the events as they see them, and they may require the Secretary to distribute this written explanation to the Membership of the Hackerspace within seven (7) days of the Secretary receiving it.
+            3. State that, if the Terminated Member so chooses, they may provide the Secretary with a written explanation of the events as they see them, and they may request the Secretary to distribute this written explanation to the Membership of the Hackerspace prior to the next monthly meeting.
         4. If the Terminated Member gives a written notice to appeal to the Secretary, they will have the right to be fairly heard at a Monthly Meeting held within the following ninety (90) days.
         5. If the Terminated Member is not satisfied that the Membership of the Hackerspace has had sufficient time to consider the written explanation, they may defer his or her right to be heard until the following Monthly Meeting.
         6. When the Terminated Member is heard at a Monthly Meeting, other Members of the Hackerspace may question the Terminated Member and the Members of the Board of Directors. The Membership of the Hackerspace shall then hold a vote to decide whether to let Board decision stand or to reinstate the Terminated Member. This decision will be final.
     4. Membership is automatically terminated upon the death of a Member.
     5. At the time an individual’s Membership is suspended or terminated, they must forfeit their method of entry into the Space, in addition to any other property owned by the Hackerspace, to a member of the Board of Directors or an agent delegated by the Board for this purpose.
-    6. The Membership Agreement shall define additional terms and procedures for suspension or termination of Membership.
+    6. The Membership Agreement may define additional terms and procedures for suspension or termination of Membership.
 
 6. The Register of Members
     1. The Secretary shall maintain the Register of Members.
@@ -76,7 +74,6 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
 ## 3. Management
 1. The Hackerspace shall have a management committee (herein also referred to as the Board of Directors, or simply the Board) comprised of, at a minimum, the following Director positions (herein also referred to as Core Director positions):
     1. President;
-    2. Vice President;
     3. Treasurer;
     4. Secretary;
     5. Chief Technology Officer.
@@ -90,18 +87,17 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
         4. Which Member shall hold each individual Director position slated for election.
     3. Elections must occur ahead of every term expiration and at least once every twelve (12) months.
     4.  Any individual who has been a Member of the organization for a minimum of six (6) months is eligible to be nominated for the Board of Directors.
-    5. Nominations shall be open for at least two (2) Monthly Meetings before Elections.
+    5. Nominations shall be open for at least one (1) Monthly Meeting before Elections.
     6. Nominations for each Director position are open until the vote is called.
     7. To be valid, nominations must be expressed to the current Secretary using any of the following methods:
         1. By voice, whether in public during the Monthly Meeting or in private;
-        2. Via email, whether publicly on the Members’ List or via private emails;
-        3. Using common mobile messaging mediums, such as SMS and instant messaging;
+        2. Via email, whether publicly on the established communications channels or via private emails;
         4. Any such method the Secretary will find acceptable.
     8. Nominees must accept the nomination before they can be included on the ballot.
     9. A Member may nominate themselves for a Director position.
     10. A nominee may, at any point before the vote is called, rescind their nomination.
     11. All retiring Board Members are eligible for re-election.
-    12. A Member may be nominated for more than one Director position, however no Member shall be elected or hold power for more than one Director position.
+    12. A Member may be nominated for more than one Director position, however no Member shall be elected to or hold power for more than one Director position.
     13. If the Director position of any Board Member becomes vacant between Elections, the Board of Directors may appoint another Full Member to fill that vacancy until the position’s term expires. 
     14. If a Board Member is absent from three consecutive Board Meetings without leave of absence, the rest of the Board of Directors may declare that person’s position vacant.
 4. Subject to these Bylaws, the role of the Board of Directors is to:
@@ -129,12 +125,6 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
         4. Convene meetings, establishing whether or not a Quorum is present;
         5. Preside over the Meetings, deciding who may speak and when;
         6. Initiate and recognize votes;
-        7. Provide a regular report of Hackerspace operations.
-    2. The Vice President is the operations officer of the organization and in this capacity shall:
-        1. Act as President should the current President be unable to perform their duties;
-        2. Oversee the internal operation of the Hackerspace;
-        3. Facilitate creation of committees and monitor their operation;
-        4. Perform functions delegated to them by the President.
     3. The Treasurer is the financial officer of the organization and in this capacity shall:
         1. Ensure the financial obligations of the Hackerspace are met;
         2. Ensure all Members pay dues in a timely manner, and that all other financial Member obligations to the organization are met;
@@ -166,18 +156,19 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
     1. The Hackerspace shall conduct the following types of meetings:
         1. Monthly Meetings
             1. Monthly Meetings are general body meetings to be conducted monthly in the Space on a day and time decided by the Board of Directors, with consideration given to accommodate the active Membership.
-            2. Attendance to Monthly Meetings is open to all Members.
-            3. Motions may be voted upon at a Monthly Meeting if at least one (1) more than half of all Members are present (herein also referred to as Member Quorum).
+            2. Attendance to Monthly Meetings is open to all Members, Guests, and all interested members of the public.
+            3. Motions may be voted upon at a Monthly Meeting if at least half of all Members are present (herein also referred to as Member Quorum).
         2. Board Meetings
             1. Board Meetings are to be conducted at least once per month on a day and time deemed agreeable to the most Board Members possible.
             2. If the membership of the Hackerspace consists solely of board members, or if a majority of Board Members vote for such, the Monthly Meeting may be combined with the Board Meeting for that month
             3. Board Meetings may be held in person, using remote conference tools, or in other formats as the Board of Directors may decide.
             4. Attendance to Board Meetings is open to any currently active Member. Any Member present at a Board Meeting not on the Board of Directors shall attend in a non-participatory manner only.
-            5. Subject to these Bylaws, the Board of Directors may regulate its own practices at Board Meetings.
-            6. Motions may be voted upon at a Board Meeting if at least one (1) more than half of Board Members are present (herein also referred to as Board Quorum).
-    2. A chairperson shall conduct Hackerspace Meetings. By default, all Hackerspace Meetings shall be chaired by the President. If the President is absent, the Vice President chairs that Meeting. If both the President and Vice President are absent, the President shall appoint another Board Member to chair that Meeting in advance. 
+            5. Any Board Member may elect to call for a Closed Session at the conclusion of a regular Board Meeting or at a date and time deemed reasonable to a quorum of Board Members. These sessions should be called to discuss sensitive matters that would not be in the best interests of the Hackerspace to disseminate to the membership, and should be called as sparingly as is practicable.
+            6. Subject to these Bylaws, the Board of Directors may regulate its own practices at Board Meetings.
+            7. Motions may be voted upon at a Board Meeting if at least half of Board Members are present (herein also referred to as Board Quorum).
+    2. A chairperson shall conduct Hackerspace Meetings. By default, all Hackerspace Meetings shall be chaired by the President. If the President is absent, the President shall appoint another Board Member to chair that Meeting in advance. 
     3. The chairperson shall adjourn the Meeting if necessary.
-    4. The following agenda format is to be followed during all Hackerspace Meetings:
+    4. Hackerspace Meetings should include the following items:
         1. Roll call and establishing quorum;
         2. Reports from Board Members and standing committees;
         3. Discussion of Old Business;
@@ -198,7 +189,7 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
     4. Votes for specific motions may be submitted by proxy. Appropriate proxies include other Members, mail-in (or email-in) voting and open announcement. The vote by proxy only affects the quorum for the motion in question and has no effect on quorum for the rest of the Meeting.
     5. On any given motion at a Meeting, the chairperson shall in good faith determine whether to vote by voices (“yay or nay”), a show of hands, or secret ballot. However, if any Member is to request a secret ballot before voting by other methods has begun, voting must then be done by secret ballot for that motion.
     6. Votes by voices that are too close to call may be validated by calling a division, voting using a different method, or recounting.
-    7. Unless otherwise noted, simple majority (more than half) of present and voting Full Members is the fundamental requirement to pass a motion by a vote of the Membership.
+    7. Unless otherwise noted, a simple majority (more than half) of present and voting Full Members is the fundamental requirement to pass a motion by a vote of the Membership.
     8. Two-thirds majority of present and voting Full Members is required to pass motions by vote of the Membership pertaining to:
         1. Suspending or changing adopted rules;
         2. Closing or limiting debate;
@@ -206,7 +197,7 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
         4. Limiting the powers of the Board of Directors;
         5. Overturning decisions made by the Board of Directors;
         6. Removing supplemental Director positions from the Board of Directors.
-    9. Unless otherwise noted, simple majority (more than half) of all active Board Members is the fundamental requirement to pass a Board motion.
+    9. Unless otherwise noted, a simple majority (more than half) of all active Board Members is the fundamental requirement to pass a Board motion.
     10. Two-thirds majority of all active Board Members is required to pass Board motions pertaining to:
         1. Suspending or changing adopted rules;
         2. Closing or limiting debate;
@@ -215,21 +206,23 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
     11. The chairperson shall have the power of the tie-breaking vote. Unless voting is performed by secret ballot, the chairperson openly casts a vote only after the results are known and they want their vote to affect the outcome. If the tie still stands, the vote is lost.
 
 ## 5. Use of Assets
-1. Notwithstanding anything herein to the contrary, the Hackerspace's money and other assets are dedicated to the furtherance of one or more exempt purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code of 1986 (or the corresponding section of any future federal tax code).
+1. Notwithstanding anything herein to the contrary, the Hackerspace's money and other assets are dedicated to the furtherance of one or more exempt purposes within the meaning of Section 501(c)(3) of the U.S. Internal Revenue Code.
 2. No part of the net earnings of the Hackerspace shall become to benefit of, or be distributable to: its members, trustees, officers, or other private persons, except that the Hackerspace shall be authorized and empowered to pay reasonable compensation for services rendered and to make payments and distributions in furtherance of the purposes set forth in the Purpose Statement herein.
 3. No substantial part of the activities of the Hackerspace shall be the carrying on of propaganda, or otherwise attempting to influence legislation, and the Hackerspace shall not participate in, or intervene in (including the publishing or distribution of statements) any political campaign on behalf of or in opposition to any candidate for public office.
 4. Distribution of Assets
-    1. Pawprint Prototyping is organized exclusively for charitable, educational, and scientific purposes, including, for such purposes, the making of distributions to organizations that qualify as exempt organizations under Section 501(c)(3) of the U.S. Internal Revenue Code of 1986 (or the corresponding section of any future federal tax code).
+    1. Pawprint Prototyping is organized exclusively for charitable, educational, and scientific purposes, including, for such purposes, the making of distributions to organizations that qualify as exempt organizations under Section 501(c)(3) of the U.S. Internal Revenue Code.
     2. Upon the dissolution of the Hackerspace, assets shall be distributed for one or more exempt purposes within the meaning of section 501(c)(3) of the Internal Revenue Code of 1986, (or the corresponding section of any future federal tax code) or shall be distributed to the federal government, or to a state or local government, for a public purpose. Any such assets not so disposed of shall be disposed of by a court of competent jurisdiction of the county in which the principal office of the Hackerspace is then located, exclusively for such purposes or to such organization or organizations, as said court shall determine, which are organized and operated exclusively for such purposes.
 
 ## 6. Amendment
 1. These Bylaws may be amended when necessary by a Board vote.
-2. All amendments approved by Board vote shall be presented to the Membership for review at the Monthly Meeting following the vote and announced on the appropriate Membership Mailing List thereafter. Members have fourteen (14) days from the date and time of this meeting to motion for a rejection of the amendment.
+2. All amendments approved by Board vote shall be presented to the Membership for review at the Monthly Meeting following the vote and announced on the appropriate Membership Communication Channel thereafter. Members have fourteen (14) days from the date and time of this meeting to motion for a rejection of the amendment.
 3. If the motion for rejection of the amendment is called and seconded, the amendment may not be ratified until motion's vote is resolved. 
-4. If no motion for rejection is called and seconded, the amendment will automatically be ratified at the expiration of the fourteen (14) day period.
+4. If no motion for rejection is called and seconded, the amendment will automatically become eligible for ratification at the expiration of the fourteen (14) day period.
+5. Once an amendment of the Bylaws has been ratified, the executed bylaws (as certified by the Secretary) shall be submitted to the appropriate government agencies.
 
 ## 7. Revision History
 1. 1.0 - 1/5/2020 - Ratified Initial Draft Of Bylaws
+2. 2.0 - 10/23/2023 - Reviewed and updated Bylaws with current standards
 
 ## Appendix A - Rules of the Hackerspace
 1. Be excellent to each other - respect your fellow hackers, their privacy and their property. Abide by the Code of Conduct.
@@ -247,7 +240,7 @@ As members of the hacking community, we the representatives of Pawprint Prototyp
 The Pawprint Prototyping Code of Conduct is forked from the !!Con Code of Conduct. It reads as follows:
 
 ### The Short Version
-Pawprint Prototyping is dedicated to providing a harassment-free space for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or anything else. We do not tolerate harassment of hackerspace participants in any form.
+Pawprint Prototyping is dedicated to providing a harassment-free space for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or anything else. We do not tolerate harassment of hackerspace users in any form.
 
 All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery may not be appropriate at times.
 


### PR DESCRIPTION
Includes backdated commits.

Having the source of truth for the bylaws in git should make diffs a lot easier to understand.

Wherever a section is deleted, I've opted to keep the original numbering in the markdown source.